### PR TITLE
Remote cache failing

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
@@ -56,6 +56,7 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /** Functionality specific to the Python rules in Bazel. */
@@ -166,8 +167,8 @@ public class BazelPythonSemantics implements PythonSemantics {
             ImmutableList.of(
                 Substitution.of(
                     "%main%", common.determineMainExecutableSource(/*withWorkspaceName=*/ true)),
-                Substitution.of("%python_binary%", pythonBinary),
-                Substitution.of("%imports%", Joiner.on(":").join(common.getImports().toList())),
+                Substitution.of("%python_binary%", pythonBinary),                 
+                Substitution.of("%imports%", Joiner.on(":").join(common.getImports().toList().stream().sorted().collect(Collectors.toList()))),
                 Substitution.of("%workspace_name%", ruleContext.getWorkspaceName()),
                 Substitution.of("%is_zipfile%", boolToLiteral(isForZipFile)),
                 Substitution.of(


### PR DESCRIPTION
python_imports in py_binary/py_test inconsistent between between fresh build. This is okay in local enviroment but causes a problem in CI when remote caching is used.